### PR TITLE
Create Skypath token verification

### DIFF
--- a/Skypath token verification
+++ b/Skypath token verification
@@ -1,0 +1,10 @@
+Update Skypath to verified Token
+
+Can you address these issues? We will need clarity before we consider tokenlisting. Buy Tax-3%, Sell Tax 6%, Blacklisting poosible
+
+The tax goes to development of the software and LP. The community voted to have the sell tax at 6% until the LP reaches $200K. 
+Blacklist is required for BSA purposes and will only be implemented if we receive subpoena request from law enforcement.
+
+Liquidity has reached over 110k now. Solid, with multiple community members creating their own pools for better price stability. 
+
+Join us on Feb 15 at 4pm EST in a joint X Space with the official AVAX team, hosted by Comics & Crypto.


### PR DESCRIPTION
Logo has been accepted and updated. 

From Unsehrtain via Telegram:
Can you address these issues? We will need clarity before we consider tokenlisting. Buy Tax-3%, Sell Tax-6%, Blacklisting possible

The tax goes to development of the software and LP. The community voted to have the sell tax at 6% until the LP reaches $200K.  Blacklist is required for BSA purposes and will only be implemented if we receive subpoena request from law enforcement.

Liquidity has reached over 110k now. Solid, with multiple community members creating their own pools for better price stability. 

Join us on Feb 15 at 4pm EST in a joint X Space with the official AVAX team, hosted by Comics & Crypto.